### PR TITLE
Handle vc in (license--project-name)

### DIFF
--- a/license.el
+++ b/license.el
@@ -500,7 +500,11 @@ nil means not to use project information."
                 ('ffip (directory-file-name (ffip-project-root)))
                 ('projectile (projectile-project-name))
                 ;; FIXME: any better way?
-                ('project (directory-file-name (project-current)))
+                ('project (directory-file-name
+			   (let ((proj (project-current)))
+			     (if (stringp proj)
+				 proj
+			       (cdr proj)))))
                 (_ nil))))
     (when name
       (concat name " Authors"))))


### PR DESCRIPTION
When using `vc', (project-current) returns a cons.  The cdr of this
cons is the directory, so try that if (project-current) isn't a
string.