### PR TITLE
Fixes

### DIFF
--- a/license.el
+++ b/license.el
@@ -5,6 +5,8 @@
 ;; Author: Zhiwei Chen <condy0919@gmail.com>
 ;; Keywords: license, tools
 ;; URL: https://github.com/condy0919/license.el
+;; Version: 0.1.0
+;; Package-Requires: ((emacs "24.1"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/license.el
+++ b/license.el
@@ -509,14 +509,14 @@ nil means not to use project information."
   (pcase (license--project-detect)
     ;; FIXME: any better way?
     ('ffip
-     (directory-file-name (ffip-project-root)))
+     (directory-file-name (funcall (symbol-function 'ffip-project-root))))
     ('projectile
-     (projectile-project-name))
+     (funcall (symbol-function 'projectile-project-name)))
     ;; FIXME: any better way?
-    ('project (let ((proj (project-current)))
-                (and proj
-                     (directory-file-name
-                      (if (stringp proj) proj (cdr proj))))))
+    ('project
+     (let ((proj (funcall (symbol-function 'project-current))))
+       (and proj (directory-file-name
+                  (if (stringp proj) proj (cdr proj))))))
     (_ nil)))
 
 (defun license-copyright-format ()

--- a/license.el
+++ b/license.el
@@ -500,11 +500,10 @@ nil means not to use project information."
                 ('ffip (directory-file-name (ffip-project-root)))
                 ('projectile (projectile-project-name))
                 ;; FIXME: any better way?
-                ('project (directory-file-name
-                           (let ((proj (project-current)))
-                             (if (stringp proj)
-                                 proj
-                               (cdr proj)))))
+                ('project (let ((proj (project-current)))
+                            (and proj
+                                 (directory-file-name
+                                  (if (stringp proj) proj (cdr proj))))))
                 (_ nil))))
     (when name
       (concat name " Authors"))))

--- a/license.el
+++ b/license.el
@@ -89,12 +89,12 @@ The priority of auto is `project' > `user'."
   :group 'license)
 
 ;; Stole from `doom-modeline`
-(defcustom license-project-detection t
+(defcustom license-project-detection 'auto
   "How to detect the project root.
 
 The default priority is `ffip' > `projectile' > 'project'.
 nil means not to use project information."
-  :type '(choice (const :tag "Auto" t)
+  :type '(choice (const :tag "Auto" auto)
                  (const :tag "Find File in Project" ffip)
                  (const :tag "Projectile" projectile)
                  (const :tag "Built-in Project" project)
@@ -496,7 +496,7 @@ nil means not to use project information."
            (append (when (fboundp 'ffip-get-project-root-directory) '(ffip))
                    (when (fboundp 'projectile-project-root) '(projectile))
                    (when (fboundp 'project-current) '(project)))))
-      (cond ((equal t license-project-detection)
+      (cond ((equal 'auto license-project-detection)
              (car loaded))
             ((member license-project-detection loaded)
              license-project-detection)

--- a/license.el
+++ b/license.el
@@ -1,7 +1,7 @@
 ;;; license.el --- Insert SPDX license header -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2020 Zhiwei Chen
-
+;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Author: Zhiwei Chen <condy0919@gmail.com>
 ;; Keywords: license, tools
 ;; URL: https://github.com/condy0919/license.el

--- a/license.el
+++ b/license.el
@@ -89,16 +89,13 @@ The priority of auto is `project' > `user'."
   :group 'license)
 
 ;; Stole from `doom-modeline`
-(defcustom license-project-detection
-  (cond ((fboundp 'ffip-get-project-root-directory) 'ffip)
-        ((fboundp 'projectile-project-root) 'projectile)
-        ((fboundp 'project-current) 'project)
-        (t nil))
+(defcustom license-project-detection t
   "How to detect the project root.
 
 The default priority is `ffip' > `projectile' > 'project'.
 nil means not to use project information."
-  :type '(choice (const :tag "Find File in Project" ffip)
+  :type '(choice (const :tag "Auto" t)
+                 (const :tag "Find File in Project" ffip)
                  (const :tag "Projectile" projectile)
                  (const :tag "Built-in Project" project)
                  (const :tag "Disable" nil))
@@ -493,30 +490,48 @@ nil means not to use project information."
   "Try to get the `user-full-name`."
   user-full-name)
 
+(defun license--project-detect ()
+  (when license-project-detection
+    (let ((loaded
+           (append (when (fboundp 'ffip-get-project-root-directory) '(ffip))
+                   (when (fboundp 'projectile-project-root) '(projectile))
+                   (when (fboundp 'project-current) '(project)))))
+      (cond ((equal t license-project-detection)
+             (car loaded))
+            ((member license-project-detection loaded)
+             license-project-detection)
+            (t
+             (error "license-project-detection method %S not loaded"
+                    license-project-detection))))))
+
 (defun license--project-name ()
   "Try to get the project name. Otherwise nil is returned."
-  (let ((name (pcase license-project-detection
-                ;; FIXME: any better way?
-                ('ffip (directory-file-name (ffip-project-root)))
-                ('projectile (projectile-project-name))
-                ;; FIXME: any better way?
-                ('project (let ((proj (project-current)))
-                            (and proj
-                                 (directory-file-name
-                                  (if (stringp proj) proj (cdr proj))))))
-                (_ nil))))
-    (when name
-      (concat name " Authors"))))
+  (pcase (license--project-detect)
+    ;; FIXME: any better way?
+    ('ffip
+     (directory-file-name (ffip-project-root)))
+    ('projectile
+     (projectile-project-name))
+    ;; FIXME: any better way?
+    ('project (let ((proj (project-current)))
+                (and proj
+                     (directory-file-name
+                      (if (stringp proj) proj (cdr proj))))))
+    (_ nil)))
 
 (defun license-copyright-format ()
   "Copyright format."
   (format "Copyright (C) %s  %s"
           (format-time-string "%Y")
-          (pcase license-copyright-holder
-            ('auto (let ((proj (license--project-name)))
-                     (if proj proj (license--user-name))))
-            ('user (license--user-name))
-            ('project (license--project-name)))))
+          (let* ((user (license--user-name))
+                 (proj (license--project-name))
+                 (proj-authors (when proj (concat proj " Authors"))))
+            (pcase license-copyright-holder
+              ('auto (or proj-authors user))
+              ('user user)
+              ('project proj)
+              (_ (error "Unknown license-copyright-holder: %S"
+                        license-copyright-holder))))))
 
 (defun license-license-format ()
   "License format."


### PR DESCRIPTION
Minor fixes; see commit messages.

MIght be useful to the wider Emacs community if we created a `spdx.el` library at some point and pushed it into MELPA. Any package dealing with SPDX data could then depend on it.